### PR TITLE
Added state_class to sensors

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -93,16 +93,22 @@ sensor:
   - platform: dsmr
     energy_delivered_lux:
       name: "Energy Consumed Luxembourg"
+      state_class: total_increasing
     energy_delivered_tariff1:
       name: "Energy Consumed Tariff 1"
+      state_class: total_increasing
     energy_delivered_tariff2:
       name: "Energy Consumed Tariff 2"
+      state_class: total_increasing
     energy_returned_lux:
       name: "Energy Produced Luxembourg"
+      state_class: total_increasing
     energy_returned_tariff1:
       name: "Energy Produced Tariff 1"
+      state_class: total_increasing
     energy_returned_tariff2:
       name: "Energy Produced Tariff 2"
+      state_class: total_increasing
     power_delivered:
       name: "Power Consumed"
       accuracy_decimals: 0


### PR DESCRIPTION
Adds support for the new Home Assistant energy dashboard

(https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics)